### PR TITLE
add: tests for object-definitions(-files)

### DIFF
--- a/codecept.conf.js
+++ b/codecept.conf.js
@@ -1,7 +1,7 @@
-const fs = require('fs')
-const path = require('path')
-const users = require('./resources/users.json')
-const {setHeadlessWhen} = require('@codeceptjs/configure')
+const fs = require('fs');
+const path = require('path');
+const users = require('./resources/users.json');
+const { setHeadlessWhen } = require('@codeceptjs/configure');
 
 // turn on headless mode when running with HEADLESS=true environment variable
 // export HEADLESS=true && npx codeceptjs run
@@ -17,16 +17,16 @@ exports.config = {
       show: true,
       browser: 'chromium',
       windowSize: '1900x1080',
-      keepCookies: true
+      keepCookies: true,
     },
     ExtendedRest: {
       require: './src/helpers/ExtendedRest.js',
       endpoint: 'http://localhost:8080/perapi',
       withCredentials: true,
       defaultHeaders: {
-        auth: users.admin
-      }
-    }
+        auth: users.admin,
+      },
+    },
   },
   include: {
     I: './src/actor.codecept',
@@ -38,33 +38,34 @@ exports.config = {
     pagesPage: './src/pages/PagesPage',
     assetsPage: './src/pages/AssetsPage',
     objectsPage: './src/pages/ObjectsPage',
-    templatesPage: './src/pages/TemplatesPage'
+    templatesPage: './src/pages/TemplatesPage',
+    objectDefinitionsPage: './src/pages/ObjectDefinitionsPage',
   },
   async teardown() {
-    const outputDir = path.join(__dirname, exports.config.output)
-    const fileName = `${users.admin.username}_session.json`
+    const outputDir = path.join(__dirname, exports.config.output);
+    const fileName = `${users.admin.username}_session.json`;
 
-    await fs.unlinkSync(path.join(outputDir, fileName))
+    await fs.unlinkSync(path.join(outputDir, fileName));
   },
   mocha: {},
   name: 'pcms-testing',
   plugins: {
     pauseOnFail: {
-      enabled: false
+      enabled: false,
     },
     retryFailedStep: {
-      enabled: true
+      enabled: true,
     },
     tryTo: {
-      enabled: false
+      enabled: false,
     },
     screenshotOnFail: {
-      enabled: true
+      enabled: true,
     },
     customLocator: {
       enabled: true,
       attribute: 'data-per-inline',
-      prefix: '$$'
+      prefix: '$$',
     },
     autoLogin: {
       enabled: true,
@@ -73,13 +74,13 @@ exports.config = {
       users: {
         admin: {
           login: async (I) => {
-            await I.loginAs('admin')
+            await I.loginAs('admin');
           },
           check: async (I) => {
-            await I.amLoggedIn()
-          }
-        }
-      }
-    }
-  }
-}
+            await I.amLoggedIn();
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/components/Explorer.js
+++ b/src/components/Explorer.js
@@ -1,52 +1,72 @@
-const askUserModal = require('./AskUserModal')
-const rightPanel = require('../components/RightPanel')
-const {I} = inject()
+const askUserModal = require('./AskUserModal');
+const rightPanel = require('../components/RightPanel');
+const { I } = inject();
 
 class Explorer {
-
-  askUserModal
-  rightPanel
+  askUserModal;
+  rightPanel;
 
   constructor() {
-    this.askUserModal = askUserModal
-    this.rightPanel = rightPanel
+    this.askUserModal = askUserModal;
+    this.rightPanel = rightPanel;
     this.locator = {
       container() {
-        return locate('.explorer').as('explorer')
+        return locate('.explorer').as('explorer');
+      },
+      select(type, title) {
+        return this.container()
+          .find('a')
+          .withAttr({ title: `select '${title}'` })
+          .as(`${type} select ("${title}")`);
       },
       infoBtn(type, title) {
         return this.container()
-            .find('a').withAttr({title: `'${title}' info`})
-            .as(`${type} info ("${title}")`)
+          .find('a')
+          .withAttr({ title: `'${title}' info` })
+          .as(`${type} info ("${title}")`);
       },
       editButton(type, title) {
         return this.container()
-            .find('a').withAttr({title: `edit '${title}'`})
-            .as(`edit ${type} ("${title}")`)
+          .find('a')
+          .withAttr({ title: `edit '${title}'` })
+          .as(`edit ${type} ("${title}")`);
       },
       deleteButton(type, title) {
         return this.container()
-            .find('a').withAttr({title: `delete '${title}'`})
-            .as(`delete ${type} ("${title}")`)
-      }
-    }
+          .find('a')
+          .withAttr({ title: `delete '${title}'` })
+          .as(`delete ${type} ("${title}")`);
+      },
+    };
+  }
+
+  seeNode(type, title) {
+    I.seeElement(this.locator.select(type, title));
+  }
+
+  dontSeeNode(type, title) {
+    I.dontSeeElement(this.locator.select(type, title));
+  }
+
+  selectNode(type, title) {
+    I.click(this.locator.select(type, title));
   }
 
   nodeInfo(type, title) {
-    I.click(this.locator.infoBtn(type, title))
+    I.click(this.locator.infoBtn(type, title));
   }
 
   deleteNode(type, title) {
-    I.waitForElement(this.locator.deleteButton(type, title), 5)
-    I.click(this.locator.deleteButton(type, title))
-    this.askUserModal.confirm()
-    I.dontSeeElement(this.locator.deleteButton(type, title))
+    I.waitForElement(this.locator.deleteButton(type, title), 5);
+    I.click(this.locator.deleteButton(type, title));
+    this.askUserModal.confirm();
+    I.dontSeeElement(this.locator.deleteButton(type, title));
   }
 
   editNode(type, title) {
-    I.click(this.locator.editButton(type, title))
+    I.click(this.locator.editButton(type, title));
   }
 }
 
-module.exports = new Explorer()
-module.exports.Explorer = Explorer
+module.exports = new Explorer();
+module.exports.Explorer = Explorer;

--- a/src/modules/PerApi.js
+++ b/src/modules/PerApi.js
@@ -1,118 +1,134 @@
-const {Request} = require('../helpers/ExtendedRest')
-const {ColorPalette} = require('../const')
-const {I} = inject()
+const { Request } = require('../helpers/ExtendedRest');
+const { ColorPalette } = require('../const');
+const { I } = inject();
 
 class PerApi {
-
   async createTenant(tenant, title = tenant, palette = ColorPalette.default) {
     return I.sendRestRequest(
-        Request.build()
-            .withUrl('/admin/createTenant.json')
-            .withPOST()
-            .withFormData({
-              fromTenant: 'themecleanflex',
-              toTenant: tenant,
-              tenantTitle: title,
-              tenantUserPwd: 'TEST_DONT_CREATE_USER',
-              colorPalette: palette
-            })
-            .as(`create tenant "${tenant}"`)
-    )
+      Request.build()
+        .withUrl('/admin/createTenant.json')
+        .withPOST()
+        .withFormData({
+          fromTenant: 'themecleanflex',
+          toTenant: tenant,
+          tenantTitle: title,
+          tenantUserPwd: 'TEST_DONT_CREATE_USER',
+          colorPalette: palette,
+        })
+        .as(`create tenant "${tenant}"`)
+    );
   }
 
   async deleteTenant(tenant) {
     return I.sendRestRequest(
-        Request.build()
-            .withUrl(`/admin/deleteTenant.json`)
-            .withPOST()
-            .withFormData({name: tenant})
-            .as(`delete tenant "${tenant}"`)
-    )
+      Request.build()
+        .withUrl(`/admin/deleteTenant.json`)
+        .withPOST()
+        .withFormData({ name: tenant })
+        .as(`delete tenant "${tenant}"`)
+    );
   }
 
   async createPage(tenant, name, title = name) {
     return I.sendRestRequest(
-        Request.build()
-            .withUrl(`/admin/createPage.json/content/${tenant}/pages`)
-            .withPOST()
-            .withFormData({
-              name,
-              templatePath: `/content/${tenant}/templates/blank`,
-              title
-            })
-            .as('create page')
-    )
+      Request.build()
+        .withUrl(`/admin/createPage.json/content/${tenant}/pages`)
+        .withPOST()
+        .withFormData({
+          name,
+          templatePath: `/content/${tenant}/templates/blank`,
+          title,
+        })
+        .as('create page')
+    );
   }
 
   async addComponent(tenant, page, componentName, drop, variation) {
-    const component = `/apps/${tenant}/components/${componentName}`
+    const component = `/apps/${tenant}/components/${componentName}`;
     return I.sendRestRequest(
-        Request.build()
-            .withUrl(
-                `/admin/insertNodeAt.json/content/${tenant}/pages/${page}/jcr:content`)
-            .withPOST()
-            .withFormData({component, drop, variation})
-            .as(`add component "${componentName}" to page "${page}"`)
-    )
+      Request.build()
+        .withUrl(
+          `/admin/insertNodeAt.json/content/${tenant}/pages/${page}/jcr:content`
+        )
+        .withPOST()
+        .withFormData({ component, drop, variation })
+        .as(`add component "${componentName}" to page "${page}"`)
+    );
   }
 
   createFolder(tenant, path, name) {
     return I.sendRestRequest(
-        Request.build()
-            .withUrl(`/admin/createFolder.json/content/${tenant}/${path}`)
-            .withPOST()
-            .withFormData({name})
-            .as(`add folder "${name}" to path "${path}"`)
-    )
+      Request.build()
+        .withUrl(`/admin/createFolder.json/content/${tenant}/${path}`)
+        .withPOST()
+        .withFormData({ name })
+        .as(`add folder "${name}" to path "${path}"`)
+    );
   }
 
   createObject(tenant, name, templatePath = 'admin/objects/tag') {
     return I.sendRestRequest(
-        Request.build()
-            .withUrl(`/admin/createObject.json/content/${tenant}/objects`)
-            .withPOST()
-            .withFormData({name, templatePath})
-            .as(`add object "${name}"`)
-    )
+      Request.build()
+        .withUrl(`/admin/createObject.json/content/${tenant}/objects`)
+        .withPOST()
+        .withFormData({ name, templatePath })
+        .as(`add object "${name}"`)
+    );
   }
 
   updateObject(tenant, name, objectPath, params) {
     return I.sendRestRequest(
-        Request.build()
-            .withUrl(`/admin/updateResource.json/content/${tenant}/objects/${name}`)
-            .withPOST()
-            .withFormData({
-              content: {
-                path: `/content/${tenant}/objects`,
-                name,
-                objectPath,
-                ...params
-              }
-            })
-            .as(`update object "${name}"`)
-    )
+      Request.build()
+        .withUrl(`/admin/updateResource.json/content/${tenant}/objects/${name}`)
+        .withPOST()
+        .withFormData({
+          content: {
+            path: `/content/${tenant}/objects`,
+            name,
+            objectPath,
+            ...params,
+          },
+        })
+        .as(`update object "${name}"`)
+    );
   }
 
   deleteObject(tenant, name) {
     return I.sendRestRequest(
-        Request.build()
-            .withUrl(`/admin/deleteNode.json/content/${tenant}/objects/${name}`)
-            .withPOST()
-            .as(`delete object "${name}"`)
-    )
+      Request.build()
+        .withUrl(`/admin/deleteNode.json/content/${tenant}/objects/${name}`)
+        .withPOST()
+        .as(`delete object "${name}"`)
+    );
   }
 
-  createTemplate(tenant, name, title = name,
-      component = `${tenant}/components/page`) {
+  createTemplate(
+    tenant,
+    name,
+    title = name,
+    component = `${tenant}/components/page`
+  ) {
     return I.sendRestRequest(
-        Request.build()
-            .withUrl(`/admin/createTemplate.json/content/${tenant}/templates`)
-            .withPOST()
-            .withFormData({name, title, component})
-            .as(`add object "${name}"`)
-    )
+      Request.build()
+        .withUrl(`/admin/createTemplate.json/content/${tenant}/templates`)
+        .withPOST()
+        .withFormData({ name, title, component })
+        .as(`add object "${name}"`)
+    );
+  }
+
+  createObjectDefinition(tenant, name) {
+    return I.sendRestRequest(
+      Request.build()
+        .withUrl(
+          `/admin/createObjectDefinition.json/content/${tenant}/object-definitions`
+        )
+        .withPOST()
+        .withFormData({ name })
+        .as(`add object-definition "${name}"`)
+    );
   }
 }
 
-module.exports = new PerApi()
-module.exports.PerApi = PerApi
+module.exports = new PerApi();
+module.exports.PerApi = PerApi;

--- a/src/pages/ObjectDefinitionsPage.js
+++ b/src/pages/ObjectDefinitionsPage.js
@@ -1,0 +1,65 @@
+const BaseNodePage = require('./bases/BaseNodePage');
+const { I } = inject();
+
+class AssetsPage extends BaseNodePage {
+  constructor() {
+    super();
+  }
+
+  getUrl(tenant) {
+    return `/content/admin/pages/object-definitions.html/path:/content/${tenant}/object-definitions`;
+  }
+
+  async addObjectDefinition(name) {
+    await I.click('add object definition');
+    await I.waitForText('create an object definition', 10);
+    await I.fillField('Object Template Name', name);
+    await I.click('Next');
+    await I.waitForText(`"name": "${name}"`, 10);
+    await I.click('Finish');
+    await I.waitForText(name, 10);
+  }
+
+  deleteObjectDefinition(name) {
+    this.explorer.deleteNode('object-definition', name);
+  }
+
+  async addFile(name, template = 'ui-schema') {
+    await I.click('add file');
+    await I.waitForText('Create File', 10);
+    await I.fillField('Filename', name);
+    await I.click('Next');
+    await I.waitForText('Insert template');
+    await I.click(template);
+    await I.waitForText('"type": "VerticalLayout",');
+    await I.click('Finish');
+    await I.waitForText(name, 10);
+  }
+
+  seeObjectDefinition(name) {
+    this.explorer.seeNode('object-definition', name);
+  }
+
+  dontSeeObjectDefinition(name) {
+    this.explorer.dontSeeNode('object-definition', name);
+  }
+
+  selectObjectDefinition(name) {
+    this.explorer.selectNode('object-definition', name);
+  }
+
+  seeFile(name) {
+    this.explorer.seeNode('object-definition-file', `${name}.json`);
+  }
+
+  dontSeeFile(name) {
+    this.explorer.dontSeeNode('object-definition-file', `${name}.json`);
+  }
+
+  deleteFile(name) {
+    this.explorer.deleteNode('object-definition-file', `${name}.json`);
+  }
+}
+
+module.exports = new AssetsPage();
+module.exports.AssetsPage = AssetsPage;

--- a/tests/object-definitions.js
+++ b/tests/object-definitions.js
@@ -1,0 +1,51 @@
+/**
+ * single-test run:
+ * npm run test -- ./tests/object-definitions.js
+ * npm run test:headful -- ./tests/object-definitions.js
+ */
+
+const utils = require('../src/modules/utils');
+
+const FEATURE_NAME = 'object-definitions';
+let TENANT;
+
+Feature(FEATURE_NAME);
+
+Before(async ({ loginAs, perApi, objectDefinitionsPage }) => {
+  TENANT = utils.generateRandomName();
+  await perApi.createTenant(TENANT);
+  await loginAs('admin');
+  await objectDefinitionsPage.navigate(TENANT);
+});
+
+After(async ({ perApi }) => {
+  await perApi.deleteTenant(TENANT);
+});
+
+Scenario(
+  'add & delete object-definition',
+  async ({ objectDefinitionsPage }) => {
+    const name = utils.generateRandomName();
+
+    await objectDefinitionsPage.addObjectDefinition(name);
+    objectDefinitionsPage.seeObjectDefinition(name);
+    objectDefinitionsPage.deleteObjectDefinition(name);
+    objectDefinitionsPage.dontSeeObjectDefinition(name);
+  }
+);
+
+Scenario(
+  'add & delete object-definition-file',
+  async ({ objectDefinitionsPage, perApi, I }) => {
+    const objectDefinition = utils.generateRandomName();
+    const file = utils.generateRandomName();
+
+    await perApi.createObjectDefinition(TENANT, objectDefinition);
+    await objectDefinitionsPage.navigate(TENANT);
+    objectDefinitionsPage.selectObjectDefinition(objectDefinition);
+    await objectDefinitionsPage.addFile(file);
+    objectDefinitionsPage.seeFile(file);
+    objectDefinitionsPage.deleteFile(file);
+    objectDefinitionsPage.dontSeeFile(file);
+  }
+);


### PR DESCRIPTION
## Linked PRs
https://github.com/headwirecom/peregrine-cms/pull/916

## Code
```js
Scenario(
  'add & delete object-definition',
  async ({ objectDefinitionsPage }) => {
    const name = utils.generateRandomName();

    await objectDefinitionsPage.addObjectDefinition(name);
    objectDefinitionsPage.seeObjectDefinition(name);
    objectDefinitionsPage.deleteObjectDefinition(name);
    objectDefinitionsPage.dontSeeObjectDefinition(name);
  }
);

Scenario(
  'add & delete object-definition-file',
  async ({ objectDefinitionsPage, perApi, I }) => {
    const objectDefinition = utils.generateRandomName();
    const file = utils.generateRandomName();

    await perApi.createObjectDefinition(TENANT, objectDefinition);
    await objectDefinitionsPage.navigate(TENANT);
    objectDefinitionsPage.selectObjectDefinition(objectDefinition);
    await objectDefinitionsPage.addFile(file);
    objectDefinitionsPage.seeFile(file);
    objectDefinitionsPage.deleteFile(file);
    objectDefinitionsPage.dontSeeFile(file);
  }
);
```

## Screenshots
![image](https://user-images.githubusercontent.com/50131232/118798987-87f11780-b89e-11eb-9553-2b7339701ae0.png)
